### PR TITLE
Handle unsupported protocols in service worker caching

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -40,8 +40,13 @@ self.addEventListener('fetch', (event) => {
           if (!networkResponse || networkResponse.status !== 200) {
             return networkResponse;
           }
-          const copy = networkResponse.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+
+          const protocol = new URL(request.url).protocol;
+          if (protocol === 'http:' || protocol === 'https:') {
+            const copy = networkResponse.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
+          }
+
           return networkResponse;
         })
         .catch(() => {


### PR DESCRIPTION
## Summary
- guard the service worker cache logic to only store responses for HTTP(S) requests, preventing chrome-extension scheme failures

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e23f226eac832081923a8c7aef2c46