### PR TITLE
Switch fallback to vladmandic face-api distribution

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -309,8 +309,9 @@ class CameraController {
       this.loadingFallback = true;
       const loadPromise = (async () => {
         const tfUrl = 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.13.0/dist/tf.min.js';
-        const faceApiUrl = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/dist/face-api.min.js';
-        const weightsUrl = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights';
+        const faceApiVersion = '1.7.23';
+        const faceApiUrl = `https://cdn.jsdelivr.net/npm/@vladmandic/face-api@${faceApiVersion}/dist/face-api.min.js`;
+        const weightsUrl = `https://cdn.jsdelivr.net/npm/@vladmandic/face-api@${faceApiVersion}/model/`; // vladmandic distribution keeps the models inside the package
 
         try {
           await this.ensureScript(tfUrl, () => typeof window.tf !== 'undefined');


### PR DESCRIPTION
## Summary
- load the face-api.js fallback from the @vladmandic/face-api CDN package that still hosts bundled models
- update the weights URI to use the package-provided model directory for compatibility

## Testing
- python -m http.server 4173 --directory public

------
https://chatgpt.com/codex/tasks/task_e_68e27c1910d48320b286c89026d53c19