### PR TITLE
Ensure camera status overlay hides after manual start

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1172,6 +1172,7 @@ function handleUserActivation() {
     .play()
     .then(() => {
       disableUserInteractionPrompt();
+      hideStatus();
       updateFaceStatusBadge('pending', '检测中...');
     })
     .catch((error) => {


### PR DESCRIPTION
## Summary
- hide the startup status overlay once manual camera playback begins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3319760148320a2747551dd9d0e84