### PR TITLE
Add downloader for Human model assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ python -m http.server --directory public 4173
 
 > ⚠️ 需要通过 HTTPS 或 localhost 打开页面，浏览器才允许访问摄像头和 FaceDetector API。
 
+### 下载 Human 模型文件
+
+`Human` 人脸检测器默认会尝试从 `public/models` 目录加载模型权重。首次克隆仓库后，请在联网环境下执行以下脚本，将最新模型下载到本地：
+
+```bash
+python scripts/download_models.py
+```
+
+脚本会读取官方清单并将所有 JSON 与二进制权重保存到 `public/models/`。若需要重新下载，可附加 `--force` 参数。下载完成后再次通过 HTTPS 启动服务即可避免 `404` 模型加载错误。
+
 ## HTTPS 启动指南
 
 若需要在纯 IP 地址环境下通过 HTTPS 访问（例如内网设备没有域名，仅能使用 `https://<ip>`），可以按照以下步骤生成证书并在本地服务器绑定：

--- a/public/app.js
+++ b/public/app.js
@@ -506,6 +506,9 @@ class HumanFaceDetector {
         console.info('Human 人脸检测器已就绪');
       } catch (error) {
         console.error('Human 人脸检测器加载失败', error);
+        if (error?.message?.includes('404')) {
+          console.info('请确认已运行 python scripts/download_models.py 下载 Human 模型文件。');
+        }
         this.human = null;
         this.ready = false;
         throw error;

--- a/public/models/.gitignore
+++ b/public/models/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!README.md
+!manifest.json
+!dog-face.json

--- a/public/models/README.md
+++ b/public/models/README.md
@@ -1,0 +1,11 @@
+# Human 模型资源
+
+该目录用于存放 [Human](https://github.com/vladmandic/human) 所需的模型 JSON 与权重文件。
+
+首次克隆仓库后，请在联网环境中执行：
+
+```bash
+python scripts/download_models.py
+```
+
+脚本会自动下载最新的官方模型文件。如果需要强制重新下载，可添加 `--force` 参数。

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Download Human AI model files into the local public/models directory."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+BASE_URL = "https://cdn.jsdelivr.net/npm/@vladmandic/human/models/"
+MANIFEST_NAME = "models.json"
+USER_AGENT = "beauty-face-model-downloader/1.0"
+
+
+@dataclass
+class DownloadTask:
+    url: str
+    destination: Path
+
+
+def build_request(url: str) -> Request:
+    return Request(url, headers={"User-Agent": USER_AGENT})
+
+
+def download_binary(task: DownloadTask, force: bool = False) -> int:
+    if task.destination.exists() and not force:
+        return 0
+
+    task.destination.parent.mkdir(parents=True, exist_ok=True)
+    with urlopen(build_request(task.url)) as response:  # nosec: B310 - controlled URL
+        data = response.read()
+
+    with open(task.destination, "wb") as file:
+        file.write(data)
+    return len(data)
+
+
+def load_remote_json(url: str) -> dict:
+    with urlopen(build_request(url)) as response:  # nosec: B310 - controlled URL
+        return json.load(response)
+
+
+def iter_model_files(manifest: dict, base_url: str, dest_dir: Path) -> Iterable[DownloadTask]:
+    models: List[dict] = manifest.get("models", [])
+    for entry in models:
+        filename = entry.get("file") or entry.get("name") or entry.get("url")
+        if not filename:
+            continue
+
+        filename = filename.rsplit("/", 1)[-1]
+        json_url = base_url + filename
+        json_dest = dest_dir / filename
+        yield DownloadTask(json_url, json_dest)
+
+        try:
+            model_def = load_remote_json(json_url)
+        except (HTTPError, URLError):
+            continue
+
+        for weight_group in model_def.get("weightsManifest", []):
+            for weight_file in weight_group.get("paths", []):
+                weight_url = base_url + weight_file
+                weight_dest = dest_dir / weight_file
+                yield DownloadTask(weight_url, weight_dest)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download Human AI model assets.")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "public" / "models",
+        help="Destination directory for downloaded models.",
+    )
+    parser.add_argument("--force", action="store_true", help="Redownload files even if they already exist.")
+    parser.add_argument("--base-url", default=BASE_URL, help="Custom base URL for Human model files.")
+    args = parser.parse_args()
+
+    dest_dir: Path = args.dest
+    base_url: str = args.base_url.rstrip("/") + "/"
+
+    manifest_url = base_url + MANIFEST_NAME
+    print(f"Fetching manifest from {manifest_url}…")
+
+    try:
+        manifest = load_remote_json(manifest_url)
+    except HTTPError as error:
+        raise SystemExit(f"Failed to download manifest: HTTP {error.code} {error.reason}") from error
+    except URLError as error:
+        raise SystemExit(f"Failed to download manifest: {error.reason}") from error
+
+    tasks = list(iter_model_files(manifest, base_url, dest_dir))
+    if not tasks:
+        raise SystemExit("Manifest did not contain any downloadable models.")
+
+    total_bytes = 0
+    for task in tasks:
+        try:
+            size = download_binary(task, force=args.force)
+        except HTTPError as error:
+            print(f"✖ Failed to download {task.url}: HTTP {error.code} {error.reason}")
+            continue
+        except URLError as error:
+            print(f"✖ Failed to download {task.url}: {error.reason}")
+            continue
+
+        if size:
+            total_bytes += size
+            print(f"✔ Downloaded {task.destination.relative_to(dest_dir)} ({size} bytes)")
+        else:
+            print(f"• Skipped {task.destination.relative_to(dest_dir)} (already exists)")
+
+    print(f"Done. Saved files into {dest_dir} (downloaded {total_bytes} bytes).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python helper that downloads the Human AI model manifest, JSON, and weight files into `public/models`
- update documentation and console messaging to explain how to fetch the models when they are missing
- add supporting README and ignore rules in `public/models`

## Testing
- python scripts/download_models.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e3347efb38832083a99ad1ece54f19