### PR TITLE
Update Human model downloader to use human-models package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python -m http.server --directory public 4173
 python scripts/download_models.py
 ```
 
-脚本会读取官方清单并将所有 JSON 与二进制权重保存到 `public/models/`。若需要重新下载，可附加 `--force` 参数。下载完成后再次通过 HTTPS 启动服务即可避免 `404` 模型加载错误。
+脚本会从官方的 [`@vladmandic/human-models`](https://www.npmjs.com/package/@vladmandic/human-models) 包所提供的清单读取模型信息，并将所有 JSON 与二进制权重保存到 `public/models/`。若需要重新下载，可附加 `--force` 参数。下载完成后再次通过 HTTPS 启动服务即可避免 `404` 模型加载错误。
 
 ## HTTPS 启动指南
 

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -10,7 +10,10 @@ from typing import Iterable, List
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-BASE_URL = "https://cdn.jsdelivr.net/npm/@vladmandic/human/models/"
+# Default CDN location for the Human model package. Newer Human releases
+# distribute model assets via the dedicated `@vladmandic/human-models`
+# package instead of bundling them with the core library.
+BASE_URL = "https://cdn.jsdelivr.net/npm/@vladmandic/human-models/models/"
 MANIFEST_NAME = "models.json"
 USER_AGENT = "beauty-face-model-downloader/1.0"
 


### PR DESCRIPTION
## Summary
- point the model download script at the @vladmandic/human-models CDN location
- update the README to document the new official model package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e350f1fee0832091680aaf0db5f395