### PR TITLE
Add manual toggle to control offline mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,14 @@
         </div>
         <div class="control-group offline-status">
           <h2>离线状态</h2>
-          <p id="offlineMessage">准备就绪，可离线使用。</p>
+          <label class="switch">
+            <input type="checkbox" id="offlineModeToggle" />
+            <span>启用离线运行</span>
+          </label>
+          <p id="offlineModeDescription" class="helper-text" data-state="inactive">
+            离线运行处于关闭状态。启用后将缓存必要资源。
+          </p>
+          <p id="offlineMessage">离线运行未启用。</p>
           <div class="console-panel">
             <h3>系统日志</h3>
             <div id="consoleOutput" class="console-output" role="log" aria-live="polite"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -265,6 +265,10 @@ canvas {
   color: #ffcc80;
 }
 
+.helper-text[data-state='error'] {
+  color: #ff8a80;
+}
+
 .helper-text[data-state='unsupported'] {
   color: #ffab91;
 }


### PR DESCRIPTION
## Summary
- add a dedicated switch in the control panel to opt in to offline support before loading the service worker
- wire the new control to register and unregister the service worker on demand while keeping the offline banner in sync
- extend helper-text styling to cover error messaging for the new offline workflow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e36a37738883208412ddc0cff35759