### PR TITLE
Add face outline toggle and improve camera status

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,10 @@
             <input type="checkbox" id="dogFaceToggle" checked />
             <span>小狗脸滤镜</span>
           </label>
+          <label class="switch">
+            <input type="checkbox" id="faceOutlineToggle" checked />
+            <span>显示人脸轮廓</span>
+          </label>
           <p id="faceDetectorMessage" class="helper-text" data-state="pending" aria-live="polite">摄像头准备中，小狗脸滤镜将自动启用。</p>
         </div>
         <div class="control-group">


### PR DESCRIPTION
## Summary
- hide the camera startup overlay as soon as playback is ready and guard status updates
- add a switch to show or hide a rounded face outline and render it on detected faces

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e377c0c60c8320ad4bf1eae2c79fec