### PR TITLE
Use CSS class to toggle status overlay visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1729,13 +1729,13 @@ function showStatus(message) {
     statusMessage.textContent = message;
   }
   if (statusOverlay) {
-    statusOverlay.hidden = false;
+    statusOverlay.classList.remove('status-overlay--hidden');
   }
 }
 
 function hideStatus() {
   if (statusOverlay) {
-    statusOverlay.hidden = true;
+    statusOverlay.classList.add('status-overlay--hidden');
   }
   if (statusMessage) {
     statusMessage.textContent = '';

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
             <div id="zoomValue">100%</div>
             <button id="zoomIn" aria-label="放大">＋</button>
           </div>
-          <div id="statusOverlay" class="status-overlay" hidden>
+          <div id="statusOverlay" class="status-overlay status-overlay--hidden">
             <div class="spinner"></div>
             <p id="statusMessage"></p>
           </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -361,6 +361,10 @@ canvas {
   z-index: 4;
 }
 
+.status-overlay--hidden {
+  display: none;
+}
+
 .spinner {
   width: 2.5rem;
   height: 2.5rem;


### PR DESCRIPTION
## Summary
- replace the status overlay's `hidden` attribute with a CSS modifier class
- update the overlay styles and JavaScript helpers to toggle the CSS class for visibility control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37a0ade488320aa2ce0e9865c5fa1